### PR TITLE
Mention the on disk location of pillars

### DIFF
--- a/config/pillar.md
+++ b/config/pillar.md
@@ -45,8 +45,8 @@ Salt pillar uses a Top file to match Salt pillar data to Salt minions. This Top 
 much like the Top file that is used to match Salt states to Salt minions.
 
 Like Salt state functions, Salt pillar is best learned by example. Create the
-`salt-vagrant-demo-master/saltstack/pillar` directory, and then create a new file
-called `top.sls`. Add the following:
+`salt-vagrant-demo-master/saltstack/pillar` directory (mapped by Vagrant to /srv/pillar),
+and then create a new file called `top.sls`. Add the following:
 
 ``` yaml
 base:


### PR DESCRIPTION
This brief note mentions where the pillar directory is mapped to (assuming a default configuration) as those not using vagrant might not know to look in the Salt master config file for the location.

Having the location mentioned specifically also helps draw attention to the difference in location to the other salt data; something the previous wording doesn't do.

This relates to https://github.com/UtahDave/salt-vagrant-demo/issues/17