### PR TITLE
Fix one-char typo in config/files.

### DIFF
--- a/config/files.md
+++ b/config/files.md
@@ -7,7 +7,7 @@ series: SaltStack Configuration Management
 step: 7
 overview:
   goals:
-    - Deliver files and folders to manages systems
+    - Deliver files and folders to managed systems
     - Understand Salt file templates
   time: 10
   difficulty: 1


### PR DESCRIPTION
Fixes the word "manages" to be "managed", because the use is part of an adjective.