### PR TITLE
Fix a handful of typos and dated examples

### DIFF
--- a/config/functions.md
+++ b/config/functions.md
@@ -269,9 +269,9 @@ restart vsftpd:
 ```
 
 Execution functions (short for "remote execution functions") are the commands
-that you call from the `salt` command line, and they start with `salt.module.*`. 
+that you call from the `salt` command line, and they start with `salt.modules.*`. 
 
-(Bit of trivia: Execution functions start with `module.*` since they were the
+(Bit of trivia: Execution functions start with `modules.*` since they were the
 first and only modules available in the initial versions of Salt. If Salt is
 ever rewritten we should probably start these with `execution.*` instead.)
 

--- a/event/beacons.md
+++ b/event/beacons.md
@@ -47,9 +47,10 @@ minion configuration file:
 ``` yaml
 beacons:
   inotify:
-    home/user/importantfile:
-      mask:
-        - modify
+    - files:
+        home/user/importantfile:
+          mask:
+            - modify
 ```
 
 ### Beacon Monitoring Interval
@@ -65,10 +66,11 @@ re-trigger the beacon, add and set the `disable_during_state_run` argument to
 ``` yaml
 beacons:
   inotify:
-    home/user/importantfile:
-      mask:
-        - modify
-    disable_during_state_run: True 
+    - files:
+        home/user/importantfile:
+          mask:
+            - modify
+    - disable_during_state_run: True
 ```
 
 As with most loop conditions, you'll probably find out the hard way when you need to add this.
@@ -82,9 +84,10 @@ provide an interval argument to a beacon. The following beacons run on 5- and
 ``` bash
 beacons:
   inotify:
-    /etc/httpd/conf.d: {}
-    /opt: {}
-    interval: 5
+    - files:
+        /etc/httpd/conf.d: {}
+        /opt: {}
+    - interval: 5
   load:
     - 1m:
       - 0.0
@@ -161,9 +164,10 @@ On `minion1`, edit the `/etc/salt/minion` file and add the following content at 
 ``` yaml
 beacons:
   inotify:
-    /home/vagrant/importantfile:
-      mask:
-        - modify
+    - files:
+        /home/vagrant/importantfile:
+          mask:
+            - modify
 ```
 Save the file, and then restart the Salt minion service:
 

--- a/event/beacons.md
+++ b/event/beacons.md
@@ -188,12 +188,9 @@ Back on your Salt master, you should have picked up an event similar to the foll
 ``` bash
 salt/beacon/minion1/inotify//home/vagrant/importantfile	{
     "_stamp": "2016-02-03T22:32:09.592113",
-    "data": {
-        "change": "IN_MODIFY",
-        "id": "minion1",
-        "path": "/home/vagrant/importantfile"
-    },
-    "tag": "salt/beacon/minion1/inotify//home/vagrant/importantfile"
+    "change": "IN_MODIFY",
+    "id": "minion1",
+    "path": "/home/vagrant/importantfile"
 }
 ```
 

--- a/event/index.md
+++ b/event/index.md
@@ -14,7 +14,7 @@ step: 1
 Here are just a few of the things our users do with Salt's event driven infrastructure:
 
 - Send a text message when a user logs on to a production server.
-- Notify a Slack or HipChat channel when a build fails.
+- Notify a Slack channel when a build fails.
 - Instantly restore a configuration file when an unauthorized change is made.
 - Automatically scale cloud resources.
 - Monitor disk, processor, ram, and other system stats and take action outside of defined thresholds.

--- a/ssh/connect.md
+++ b/ssh/connect.md
@@ -28,8 +28,10 @@ As is common in Salt, the roster system can be extended. You can currently use a
 - [cloud](https://docs.saltstack.com/en/latest/ref/roster/all/salt.roster.cloud.html)
 - [clustershell](https://docs.saltstack.com/en/latest/ref/roster/all/salt.roster.clustershell.html)
 - [flat (default)](https://docs.saltstack.com/en/latest/ref/roster/all/salt.roster.flat.html)
-- [range (in development)](https://docs.saltstack.com/en/develop/ref/roster/all/salt.roster.range.html)
+- [range](https://docs.saltstack.com/en/develop/ref/roster/all/salt.roster.range.html)
 - [scan](https://docs.saltstack.com/en/latest/ref/roster/all/salt.roster.scan.html)
+- [sshconfig](https://docs.saltstack.com/en/latest/ref/roster/all/salt.roster.sshconfig.html)
+- [terraform](https://docs.saltstack.com/en/latest/ref/roster/all/salt.roster.terraform.html)
 
 This guide uses the flat file roster.
 

--- a/system/plugins.md
+++ b/system/plugins.md
@@ -38,7 +38,7 @@ Configuration | Configures targeted systems to match a desired state.
 
 #### What does it mean to be "pluggable"?
 
-Salt doesn't define a built-in way to perform the task for any subsystem, each subsystem simply delegates its work to a plug-in. Salt provides a default plug-in for each system, but changing the plug-in in most cases is as simple as updating a configuration file. This pluggability is what makes Salt so flexibile. 
+Salt doesn't define a built-in way to perform the task for any subsystem, each subsystem simply delegates its work to a plug-in. Salt provides a default plug-in for each system, but changing the plug-in in most cases is as simple as updating a configuration file. This pluggability is what makes Salt so flexible.
 
 {: end sidebar :}
 

--- a/system/python.md
+++ b/system/python.md
@@ -22,7 +22,7 @@ This section explains the Python basics that help you better understand how Salt
 
 #### Modules are used differently by each subsystem!
 
-If you glanced at the salt source folder, you are probably feeling a bit overwhelmed by Python code about now. Fortunately, there are only two module types that you really need to interact with directly: execution modules (`salt.module`) and state modules (`salt.states`).
+If you glanced at the salt source folder, you are probably feeling a bit overwhelmed by Python code about now. Fortunately, there are only two module types that you really need to interact with directly: execution modules (`salt.modules`) and state modules (`salt.states`).
 
 The modules that let you format job results (`salt.outputters`) are enabled using the `--out` argument when calling the `salt` command. Most of the other subsystem modules are enabled in the Salt master or minion configuration files, including auth, beacons, engines, fileserver, pillar, proxy, returners, and probably one or two others that I missed. And some you don't have to do anything with, such as grains, since they do their work automatically.
 
@@ -34,7 +34,7 @@ Here is what you need to know:
 
 - All of the modules are in the `salt` folder in the source. A separate folder exists for each subsystem, and each module is a separate file ending in `.py`.
 
-- Modules are namespaced in the format salt.*subsystem*.*module*. This namespace is visible in the docs, so you can quickly tell which type of subystem module you are viewing. One point of confusion: execution modules start with `salt.module` since they were the first and only modules available in the initial versions of Salt (when time travel is invented we should probably start these with `salt.execution` instead).
+- Modules are namespaced in the format salt.*subsystem*.*module*. This namespace is visible in the docs, so you can quickly tell which type of subystem module you are viewing. One point of confusion: execution modules start with `salt.modules` since they were the first and only modules available in the initial versions of Salt (when time travel is invented we should probably start these with `salt.execution` instead).
 
 - Modules contain as many or as few functions as are needed. The file execution module (`salt.modules.file`) has a lot of functions because file management is sort of a big deal. The uwsgi stats server execution module (`salt.modules.uwsgi`) has just one.
 


### PR DESCRIPTION
Changes:

* Add current roster modules
* Modernize inotify event return example
* Fix beacons syntax
* Remove dated HipChat reference
* Fix `state.module` references
* Fix typo in system/plugins: "flexibile"